### PR TITLE
Fix urgent call heading layout

### DIFF
--- a/source/index.md
+++ b/source/index.md
@@ -3,7 +3,19 @@ layout: main.hbs
 title: About Genital Autonomy Collective
 ---
 
-# ⚠️ Urgent Call to Action ⚠️
+<h1 class="urgent-call">Urgent Call to Action</h1>
+<style>
+  .urgent-call {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    gap: 0.5em;
+  }
+  .urgent-call::before,
+  .urgent-call::after {
+    content: "⚠️";
+  }
+</style>
 ## Intersex Plaintiff Needed Within 30 Days
 
 **A historic opportunity to protect intersex children under the Oregon Constitution is at risk of being lost forever.**


### PR DESCRIPTION
## Summary
- fix visual layout of the "Urgent Call to Action" heading so the warning signs are positioned consistently

## Testing
- `node site.js`

------
https://chatgpt.com/codex/tasks/task_e_6883e5a5152c8321893f4be7ebbd82cf